### PR TITLE
fix: valid whatis entry

### DIFF
--- a/mcoral.go
+++ b/mcoral.go
@@ -8,7 +8,7 @@ import (
 
 // NewManPage creates a new mango.ManPage from a coral.Command.
 func NewManPage(section uint, c *coral.Command) (*mango.ManPage, error) {
-	manPage := mango.NewManPage(section, c.Name(), c.Short).
+	manPage := mango.NewManPage(section, c.Name(), c.Name()+" - "+c.Short).
 		WithLongDescription(c.Long)
 
 	if err := AddCommand(manPage, c); err != nil {


### PR DESCRIPTION
According to lintian, it seems the `SH` section should begin with the command name, then a ` - `, then its actual short description.

this is apparently used by `whatis`.

not sure if its better doing this here or in mango itself, cc/ @muesli 