### PR TITLE
feat: add support for examples

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -20,6 +20,7 @@ var (
 		RunE: func(cmd *coral.Command, agrs []string) error {
 			return nil
 		},
+		Example: "mango --help",
 	}
 
 	oneCmd = &coral.Command{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/muesli/coral v1.0.0
-	github.com/muesli/mango v0.1.0
+	github.com/muesli/mango v0.2.0
 	github.com/muesli/mango-pflag v0.1.0
 	github.com/muesli/roff v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,9 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/muesli/coral v1.0.0 h1:odyqkoEg4aJAINOzvnjN4tUsdp+Zleccs7tRIAkkYzU=
 github.com/muesli/coral v1.0.0/go.mod h1:bf91M/dkp7iHQw73HOoR9PekdTJMTD6ihJgWoDitde8=
-github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=
 github.com/muesli/mango v0.1.0/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango v0.2.0 h1:iNNc0c5VLQ6fsMgAqGQofByNUBH2Q2nEbD6TaI+5yyQ=
+github.com/muesli/mango v0.2.0/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
 github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe7Sg=
 github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=

--- a/mcoral.go
+++ b/mcoral.go
@@ -27,9 +27,11 @@ func addCommandTree(m *mango.ManPage, c *coral.Command, parent *mango.Command) e
 	if parent == nil {
 		// set root command
 		item = mango.NewCommand(c.Name(), "", "")
+		item.Example = c.Example
 		m.Root = *item
 	} else {
 		item = mango.NewCommand(c.Name(), c.Short, c.Use)
+		item.Example = c.Example
 		if err := parent.AddCommand(item); err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds support to add cobra command examples to the manpage.

Ref: https://github.com/muesli/mango/pull/13